### PR TITLE
Modifying a function name to align with approved verbs

### DIFF
--- a/CreateProfile/Public/New-Profile.ps1
+++ b/CreateProfile/Public/New-Profile.ps1
@@ -4,9 +4,9 @@
 .DESCRIPTION
    This function will create a new local user and then map it to a user profile based on a SID.  After that it will load the user profile.
 .EXAMPLE
-   Create-NewProfile -UserName 'someusername' -password 'Password'
+   New-Profile -UserName 'someusername' -password 'Password'
 #>
-function Create-NewProfile {
+function New-Profile {
  
     [CmdletBinding()]
     [Alias()]

--- a/tests/CreateProfile.Tests.ps1
+++ b/tests/CreateProfile.Tests.ps1
@@ -32,7 +32,7 @@ Describe "$module PowerShell Module Tests" {
 
 
 
-    $pubFunctions = ('Create-NewProfile',                    
+    $pubFunctions = ('New-Profile',                    
                      'New-LocalUser'
                     )
 


### PR DESCRIPTION
Modifying a function name from Create-NewProfile to New-Profile to align with approved verbs. This is both for the tests and for the actual public function name.